### PR TITLE
Don't include gnome-getting-started-docs

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -3,7 +3,6 @@ FROM registry.endlessm-sf.com/eos:${BRANCH}
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gir1.2-gnomedesktop-3.0 \
-        gnome-getting-started-docs \
         gnome-user-guide \
         python3-boto3 \
         python3-gi \


### PR DESCRIPTION
- Don't include gnome-getting-started-docs: None of the help content in this package is applicable to Endless OS. It is not included in the OS.

https://phabricator.endlessm.com/T32707

