### PR TITLE
Include Endless OS's os-release in build environment

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -2,6 +2,7 @@ ARG BRANCH=master
 FROM registry.endlessm-sf.com/eos:${BRANCH}
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        eos-version-number \
         gir1.2-gnomedesktop-3.0 \
         gnome-getting-started-docs \
         gnome-user-guide \


### PR DESCRIPTION
This ensures that tests like:

  <if:when test="platform:endless">

evaluate to true. These are used to substitute Endless-specific
paragraphs for GNOME sections that must be replaced wholesale.

https://phabricator.endlessm.com/T32706
