### PR TITLE
Set mallard platform conditional to endless

### DIFF
--- a/build.xsl
+++ b/build.xsl
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <!-- Set platform:endless to handle platform conditionals. -->
+  <xsl:param name="mal.if.platform" select="'platform:endless'"/>
+</xsl:stylesheet>

--- a/generate-html-docs.sh
+++ b/generate-html-docs.sh
@@ -2,6 +2,7 @@
 
 SRCDIR=$(dirname "$0")
 DEST="$SRCDIR/build"
+XSL="$SRCDIR/build.xsl"
 
 function show_need_yelp() {
     echo "  ERROR: this script requires 'yelp-build'"
@@ -65,7 +66,7 @@ for doc_path in /usr/share/help/*/gnome-help; do
 
     echo -n "      $lang..."
 
-    yelp-build html -o "$doc_out" "$doc_path"/*.page
+    yelp-build html -o "$doc_out" -x "$XSL" "$doc_path"/*.page
 
     echo " OK"
 


### PR DESCRIPTION
Our docs have several conditional elements testing `platform:endless`.
`yelp` sets this at runtime based from reading `/etc/os-release` and the
`XDG_CURRENT_DESKTOP` environment variable, but `yelp-build` has no such
concept. Bring back some custom XSL to set the mallard conditional
directly.

https://phabricator.endlessm.com/T32706