### PR TITLE
generate-html-docs: Fix check for yelp-build's presence

### DIFF
--- a/generate-html-docs.sh
+++ b/generate-html-docs.sh
@@ -43,7 +43,7 @@ while true; do
     esac
 done
 
-yelp-build --help >/dev/null 2>&1 || show_need_yelp
+command -v yelp-build >/dev/null 2>&1 || show_need_yelp
 
 echo ""
 echo "  Endless OS Doc2HTML script"


### PR DESCRIPTION
It looks like the '--help' argument has been dropped from yelp-build, as
'yelp-build --help' now prints an error and exit with status of 1,
breaking our check.

The shell building 'command' is documented to exit with a status of 0 if
the command was found and 1 otherwise, when used with -v, so this seems
a safe bet.

https://phabricator.endlessm.com/T33073