### PR TITLE
Build and publish to branched subdirectories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,8 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh './generate-html-docs.sh'
-                sh './generate-index.py'
+                sh './generate-html-docs.sh -b "$BRANCH"'
+                sh './generate-index.py -b "$BRANCH"'
             }
         }
 
@@ -20,7 +20,7 @@ pipeline {
                                   credentialsId: 'iam-user-jenkins-jobs',
                                   accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                                   secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-                    sh "./publish-docs.py --region ${params.REGION} ${params.DISTRIBUTION ? "--cloudfront ${params.DISTRIBUTION}" : ""} ${params.BUCKET}"
+                    sh "./publish-docs.py -b ${params.BRANCH} --region ${params.REGION} ${params.DISTRIBUTION ? "--cloudfront ${params.DISTRIBUTION}" : ""} ${params.BUCKET}"
                 }
             }
         }

--- a/build.sh
+++ b/build.sh
@@ -48,5 +48,7 @@ $PODMAN build --pull -t "$TAG" --build-arg "BRANCH=${BRANCH}" \
 
 # Build the docs in the container.
 ABSSRC=$(readlink -f "$SRC")
-$PODMAN run --rm -v "$ABSSRC:/src" -w /src "$TAG" ./generate-html-docs.sh
-$PODMAN run --rm -v "$ABSSRC:/src" -w /src "$TAG" ./generate-index.py
+$PODMAN run --rm -v "$ABSSRC:/src" -w /src "$TAG" \
+    ./generate-html-docs.sh -b "$BRANCH"
+$PODMAN run --rm -v "$ABSSRC:/src" -w /src "$TAG" \
+    ./generate-index.py -b "$BRANCH"

--- a/generate-html-docs.sh
+++ b/generate-html-docs.sh
@@ -2,6 +2,7 @@
 
 SRCDIR=$(dirname "$0")
 DEST="$SRCDIR/build"
+BRANCH=
 XSL="$SRCDIR/build.xsl"
 
 function show_need_yelp() {
@@ -17,13 +18,15 @@ function show_need_yelp() {
 
 function usage() {
     cat <<EOF
-Usage: $0 [OPTION]... SRC DEST
+Usage: $0 [OPTION]...
 
-  -h, --help        display this help and exit
+  -o, --outdir OUTDIR	directory to build docs (default: $DEST)
+  -b, --branch BRANCH	build in BRANCH subdirectory
+  -h, --help		display this help and exit
 EOF
 }
 
-ARGS=$(getopt -o o:h -l outdir:,help -n "$0" -- "$@")
+ARGS=$(getopt -o o:b:h -l outdir:,branch:,help -n "$0" -- "$@")
 eval set -- "$ARGS"
 
 while true; do
@@ -32,6 +35,10 @@ while true; do
 	    DEST=$2
 	    shift 2
 	    ;;
+        -b|--branch)
+            BRANCH=$2
+            shift 2
+            ;;
         -h|--help)
             usage
             exit 0
@@ -48,6 +55,11 @@ command -v yelp-build >/dev/null 2>&1 || show_need_yelp
 echo ""
 echo "  Endless OS Doc2HTML script"
 echo ""
+
+# Build to branch specific subdir if specified.
+if [ -n "$BRANCH" ]; then
+    DEST="$DEST/$BRANCH"
+fi
 
 # Delete existing build directory
 if [ -d "$DEST" ]; then

--- a/generate-index.py
+++ b/generate-index.py
@@ -9,7 +9,7 @@ import jinja2
 import sys
 
 gi.require_version('GnomeDesktop', '3.0')
-from gi.repository import GnomeDesktop
+from gi.repository import GnomeDesktop  # noqa: E402
 
 SRCDIR = os.path.dirname(__file__)
 DEFAULT_BUILDDIR = os.path.join(SRCDIR, 'build')
@@ -18,12 +18,15 @@ ap = ArgumentParser(description='Generate helpcenter index page')
 ap.add_argument('-d', '--builddir', metavar='DIR', default=DEFAULT_BUILDDIR,
                 help=(f'path to HTML build directory '
                       f'(default: {DEFAULT_BUILDDIR})'))
+ap.add_argument('-b', '--branch', help='build in BRANCH subdirectory')
 ap.add_argument('-f', '--force', action='store_true',
                 help='overwrite existing index.html')
 ap.add_argument('-n', '--dry-run', action='store_true',
                 help='only show the generated HTML')
 args = ap.parse_args()
 
+if args.branch:
+    args.builddir = os.path.join(args.builddir, args.branch)
 index_path = os.path.join(args.builddir, 'index.html')
 if not (args.dry_run or args.force) and os.path.exists(index_path):
     print(f'error: {index_path} already exists', file=sys.stderr)

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             <div class="contents pagewide">
               <ul class="list">
                 {%- for language, entry in catalogs %}
-                <li><a href="{{ entry }}/index.html">{{ language }}</a></li>
+                <li><a href="{{ entry }}/">{{ language }}</a></li>
                 {%- endfor %}
               </ul>
             </div>


### PR DESCRIPTION
Instead of having each OS branch publish to the root of a deployment, allow each OS branch to publish to a subdirectory. That way we can deploy them all on the production helpcenter with a minimal root index.

https://phabricator.endlessm.com/T32822