### PR TITLE
Jenkinsfile: Ensure current packages are used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,11 @@ pipeline {
     agent {
         dockerfile {
             filename 'Dockerfile-build'
-            additionalBuildArgs "--build-arg BRANCH=${params.BRANCH}"
+
+            // Since the build depends on the packaged tools and
+            // documents, add --pull and --no-cache to ensure the
+            // current packages are always used.
+            additionalBuildArgs "--pull --no-cache --build-arg BRANCH=${params.BRANCH}"
         }
     }
 


### PR DESCRIPTION
Since the build depends on the packaged tools and documents, add the `--pull` and `--no-cache` build options to ensure the current packages are always used. Otherwise a cached container with stale packages might be used.

https://phabricator.endlessm.com/T32822