### PR TITLE
Update gnome-user-docs package name

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -3,7 +3,7 @@ FROM docker.io/endlessm/eos:${BRANCH}
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gir1.2-gnomedesktop-3.0 \
-        gnome-user-guide \
+        gnome-user-docs \
         python3-boto3 \
         python3-gi \
         python3-jinja2 \


### PR DESCRIPTION
gnome-user-guide was, in both buster and bullseye, a transitional
package that depended on gnome-user-docs. It has been removed in
bookworm.

https://phabricator.endlessm.com/T35150
